### PR TITLE
WebApp用にnext.configを編集。

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  images: {
-    unoptimized: true
-  },
-  output: 'export'
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
WebAppのデプロイ時にはoutput: 'export'ははずした方がいいっぽい？
静的ビルドでは無い場合は削除する必要があるっぽい。